### PR TITLE
SC2086 - Double quote

### DIFF
--- a/etc/t-completion.sh
+++ b/etc/t-completion.sh
@@ -441,10 +441,10 @@ help) completions='-H --host -C --color -P --profile' ;;
           *) completions="$COMMANDS" ;;
         esac
 
-        COMPREPLY=( $( compgen -W "$completions" -- $cur ))
+        COMPREPLY=( $( compgen -W "$completions" -- "$cur" ))
         return 0
 
       }
 
-      complete -F _t $filenames t
+      complete -F _t "$filenames" t
       


### PR DESCRIPTION
[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) Double quote to prevent globbing and word splitting.