### PR TITLE
Prevent crash on empty list of followers

### DIFF
--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -183,6 +183,7 @@ module T
     end
 
     def print_users(users) # rubocop:disable CyclomaticComplexity
+      return if users.nil?
       users = case options['sort']
       when 'favorites'
         users.sort_by { |user| user.favorites_count.to_i }


### PR DESCRIPTION
Users with no followers caused a crash in "print_users".