### PR TITLE
RuboCop clean-up

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -892,7 +892,7 @@ module T
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
-    def whois(user) # rubocop:disable CyclomaticComplexity
+    def whois(user)
       require 't/core_ext/string'
       opts = {}
       opts[:include_entities] = !!options['decode_uris']

--- a/lib/t/collectable.rb
+++ b/lib/t/collectable.rb
@@ -30,7 +30,7 @@ module T
       end.flatten.compact
     end
 
-    def collect_with_page(collection = ::Set.new, page = 1, previous = nil, &block) # rubocop:disable ParameterLists
+    def collect_with_page(collection = ::Set.new, page = 1, previous = nil, &block)
       tweets = Retryable.retryable(tries: 3, on: Twitter::Error, sleep: 0) do
         block.call(page)
       end

--- a/tasks/zsh.rake
+++ b/tasks/zsh.rake
@@ -84,7 +84,7 @@ end
 def command_function(command)
   %(_t_#{command.name}() {
   _arguments \\
-    #{ command_function_arguments(command) }
+    #{command_function_arguments(command)}
 }
 )
 end
@@ -119,7 +119,7 @@ end
 def arguments_function(subcommand)
   klass = T.const_get subcommand.name.capitalize
   %(__t_#{subcommand.name}_arguments() {
-  _args=(#{klass.tasks.collect { |t| t.last.name }.join("\n    ") }
+  _args=(#{klass.tasks.collect { |t| t.last.name }.join("\n    ")}
   )
   compadd "$@" -k _args
 }


### PR DESCRIPTION
Fix two outstanding RuboCop offences and drop unnecessary disablings (RuboCop started flagging them in recent versions).