### PR TITLE
Reply without a status opens a text editor

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -600,7 +600,8 @@ module T
     method_option 'all', aliases: '-a', type: :boolean, desc: 'Reply to all users mentioned in the Tweet.'
     method_option 'location', aliases: '-l', type: :string, default: nil, desc: "Add location information. If the optional 'latitude,longitude' parameter is not supplied, looks up location by IP address."
     method_option 'file', aliases: '-f', type: :string, desc: 'The path to an image to attach to your tweet.'
-    def reply(status_id, message)
+    def reply(status_id, message = nil)
+      message = T::Editor.gets if message.to_s.empty?
       status = client.status(status_id.to_i, include_my_retweet: false)
       users = Array(status.user.screen_name)
       if options['all']

--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -846,7 +846,7 @@ module T
     method_option 'location', aliases: '-l', type: :string, default: nil, desc: "Add location information. If the optional 'latitude,longitude' parameter is not supplied, looks up location by IP address."
     method_option 'file', aliases: '-f', type: :string, desc: 'The path to an image to attach to your tweet.'
     def update(message = nil)
-      message = T::Editor.gets if message.nil? || message.empty?
+      message = T::Editor.gets if message.to_s.empty?
       opts = {trim_user: true}
       add_location!(options, opts)
       status = if options['file']

--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -596,7 +596,7 @@ module T
       say number_with_delimiter(reach.size)
     end
 
-    desc 'reply TWEET_ID MESSAGE', 'Post your Tweet as a reply directed at another person.'
+    desc 'reply TWEET_ID [MESSAGE]', 'Post your Tweet as a reply directed at another person.'
     method_option 'all', aliases: '-a', type: :boolean, desc: 'Reply to all users mentioned in the Tweet.'
     method_option 'location', aliases: '-l', type: :string, default: nil, desc: "Add location information. If the optional 'latitude,longitude' parameter is not supplied, looks up location by IP address."
     method_option 'file', aliases: '-f', type: :string, desc: 'The path to an image to attach to your tweet.'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3927,6 +3927,12 @@ WOEID     Parent ID  Type       Name           Country
         expect($stdout.string.split("\n").first).to eq 'Tweet posted by @testcli.'
       end
     end
+    context 'no status provided' do
+      it 'opens an editor to prompt for the status' do
+        expect(T::Editor).to receive(:gets).and_return 'Testing'
+        @cli.update
+      end
+    end
   end
 
   describe '#users' do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2597,6 +2597,12 @@ ID                   Posted at     Screen name       Text
         expect($stdout.string.split("\n").first).to eq 'Reply posted by @testcli to @joshfrench.'
       end
     end
+    context 'no status provided' do
+      it 'opens an editor to prompt for the status' do
+        expect(T::Editor).to receive(:gets).and_return 'Testing'
+        @cli.reply('263813522369159169')
+      end
+    end
   end
 
   describe '#report_spam' do


### PR DESCRIPTION
fixes #298 

Before:

```
$ t reply 672450972233240576
ERROR: "t reply" was called with arguments ["672450972233240576"]
Usage: "t reply TWEET_ID MESSAGE"
```

After:

```
$ t reply 672450972233240576
# opens editor to prompt for status...
```