### PR TITLE
Updated help text for trends to match actual amount returned.

### DIFF
--- a/etc/t-completion.zsh
+++ b/etc/t-completion.zsh
@@ -52,7 +52,7 @@ _t (){
       "ruler[Prints a 140-character ruler]" \
       "status[Retrieves detailed information about a Tweet.]" \
       "timeline[Returns the 20 most recent Tweets posted by a user.]" \
-      "trends[Returns the top 10 trending topics.]" \
+      "trends[Returns the top 50 trending topics.]" \
       "trend_locations[Returns the locations for which Twitter has trending topic information.]" \
       "unfollow[Allows you to stop following users.]" \
       "update[Post a Tweet.]" \

--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -778,7 +778,7 @@ module T
     end
     map %w(tl) => :timeline
 
-    desc 'trends [WOEID]', 'Returns the top 10 trending topics.'
+    desc 'trends [WOEID]', 'Returns the top 50 trending topics.'
     method_option 'exclude-hashtags', aliases: '-x', type: :boolean, desc: 'Remove all hashtags from the trends list.'
     def trends(woe_id = 1)
       opts = {}


### PR DESCRIPTION
When running "t --help" or "t help trends", the help text states that it will return 10 trends, but it actually returns 50. I updated the help text accordingly. For bug https://github.com/sferik/t/issues/337