### PR TITLE
Update code to conform to new rubocop rules

### DIFF
--- a/lib/t/identicon.rb
+++ b/lib/t/identicon.rb
@@ -30,7 +30,7 @@ module T
     end
 
     def bg(bit)
-      bit == 0 ? "\033[48;5;#{@bcolor}m" : "\033[48;5;#{@fcolor}m"
+      bit.zero? ? "\033[48;5;#{@bcolor}m" : "\033[48;5;#{@fcolor}m"
     end
   end
 

--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -136,7 +136,7 @@ module T
       # Save 6 chars for icon, ensure at least 3 lines long
       lines = wrapped(HTMLEntities.new.decode(message), indent: 2, width: terminal_width - (6 + 5))
       lines.unshift(set_color("  @#{from_user}", :bold, :yellow))
-      lines.push(*Array.new([3 - lines.length, 0].max) { '' })
+      lines.concat(Array.new([3 - lines.length, 0].max) { '' })
 
       $stdout.puts lines.zip(icon.lines).map { |x, i| "  #{i || '      '}#{x}" }
     end

--- a/lib/t/rcfile.rb
+++ b/lib/t/rcfile.rb
@@ -20,7 +20,7 @@ module T
       if possibilities.size == 1
         possibilities.first
       else
-        raise(ArgumentError.new("Username #{username} is #{possibilities.size < 1 ? 'not found.' : 'ambiguous, matching ' + possibilities.join(', ')}"))
+        raise(ArgumentError.new("Username #{username} is #{possibilities.empty? ? 'not found.' : 'ambiguous, matching ' + possibilities.join(', ')}"))
       end
     end
 
@@ -118,7 +118,7 @@ module T
 
     def write
       require 'yaml'
-      File.open(@path, File::RDWR | File::TRUNC | File::CREAT, 0600) do |rcfile|
+      File.open(@path, File::RDWR | File::TRUNC | File::CREAT, 0o0600) do |rcfile|
         rcfile.write @data.to_yaml
       end
     end


### PR DESCRIPTION
Fix for issue: https://github.com/sferik/t/issues/339

One reported issue remains, but is due to a recently-fixed bug in rubocop itself, misreporting "shadowed" exceptions, the fix for which is in the lastest rubocop master branch and will presumably be included in the next release of that project.