### PR TITLE
Specify pry-byebug for Ruby v2.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,12 @@ gem 'jruby-openssl', platforms: :jruby
 
 group :development do
   gem 'pry'
-  platforms :ruby_19, :ruby_20 do
+  platforms :ruby_19 do
     gem 'pry-debugger'
+    gem 'pry-stack_explorer'
+  end
+  platforms :ruby_20 do
+    gem 'pry-byebug'
     gem 'pry-stack_explorer'
   end
 end


### PR DESCRIPTION
When trying to run `bundle install` to prepare to build t with Ruby v2.x, it returns this error message: https://gist.github.com/catleeball/aade8911f2c2e758004b3629b7840aeb

Specifying pry-byebug works for Ruby 2; it's a fork of pry-debugger that includes support for Ruby 2.
