### PR TITLE
[Issue No #352] Fix --csv option doesn't escape newlines

### DIFF
--- a/lib/t/utils.rb
+++ b/lib/t/utils.rb
@@ -91,7 +91,7 @@ module T
       require 'htmlentities'
       text = HTMLEntities.new.decode(message.full_text)
       text = decode_uris(text, message.uris) if decode_full_uris
-      text
+      text.gsub(/\n+/,' ')
     end
 
     def decode_uris(full_text, uri_entities)

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -125,13 +125,9 @@ ID,Posted at,Screen name,Text
 415600159486005248,2013-12-24 21:49:34 +0000,_KAIRYALS,My birthday cake was bomb http://t.co/LquXc7JXj4
 415600159456632832,2013-12-24 21:49:34 +0000,frozenharryx,RT @LouisTexts: whos tessa? http://t.co/7DJQlmCfuu
 415600159452438528,2013-12-24 21:49:34 +0000,MIKEFANTASMA,"Pues nada, aquí armando mi regalo de navidad solo me falta la cara y ya hago mi pedido con santa!.. http://t.co/iDC7bE9o4M"
-415600159444439040,2013-12-24 21:49:34 +0000,EleManera,"RT @xmyband: La gente che si arrabbia perché Harry non ha fatto gli auguri a Lou su Twitter.
-Non vorrei smontarvi, ma esistono i cellulari e i messaggi."
+415600159444439040,2013-12-24 21:49:34 +0000,EleManera,"RT @xmyband: La gente che si arrabbia perché Harry non ha fatto gli auguri a Lou su Twitter. Non vorrei smontarvi, ma esistono i cellulari e i messaggi."
 415600159444434944,2013-12-24 21:49:34 +0000,BigAlFerguson,“@IrishRace; Merry Christmas to all our friends and followers from all @IrishRaceRally have a good one! http://t.co/rXFsC2ncFo” @Danloi1
-415600159436066816,2013-12-24 21:49:34 +0000,goksantezgel,"RT @nederlandline: Tayyip bey evladımızı severiz Biz ona dua ediyoruz.Fitnelere SAKIN HA!
-Mahmud Efndi (ks)
-#BedduayaLanetDuayaDavet 
-http://t.co/h6MUyHxr9x"""
+415600159436066816,2013-12-24 21:49:34 +0000,goksantezgel,"RT @nederlandline: Tayyip bey evladımızı severiz Biz ona dua ediyoruz.Fitnelere SAKIN HA! Mahmud Efndi (ks) #BedduayaLanetDuayaDavet  http://t.co/h6MUyHxr9x"""
 415600159427670016,2013-12-24 21:49:34 +0000,MaimounaLvb,RT @sissokodiaro: Miss mali pa pour les moche mon ga http://t.co/4WnwzoLgAD
 415600159423483904,2013-12-24 21:49:34 +0000,MrSilpy,@MrKATANI http://t.co/psk7K8rcND
 415600159423094784,2013-12-24 21:49:34 +0000,hunterdl19,RT @MadisonBertini: Jakes turnt http://t.co/P60gYZNL8z

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -75,6 +75,23 @@ describe T::Utils do
     end
   end
 
+  describe '#decode_full_text' do
+    encoded_text = "RT @person_1: #tag1 test tweet with url. https://test.com/testurl"
+    tweet1 = Twitter::Tweet.new(id: 1, text: encoded_text)
+    it 'returns decoded string' do
+      expect(@test.send(:decode_full_text, tweet1, true)).to eq(encoded_text)
+    end
+    context 'with new line character in text' do
+      encoded_text_with_new_line = "RT @person_1: #tag1 test tweet with
+url.
+https://test.com/testurl"
+      tweet2 = Twitter::Tweet.new(id: 1, text: encoded_text_with_new_line)
+      it 'returns decoded string with out new line character' do
+        expect(@test.send(:decode_full_text, tweet2, true)).to eq(encoded_text)
+      end
+    end
+  end
+
   describe '#strip_tags' do
     it 'returns string sans tags' do
       expect(@test.send(:strip_tags, '<a href="http://twitter.com/#!/download/iphone" rel="nofollow">Twitter for iPhone</a>')).to eq 'Twitter for iPhone'


### PR DESCRIPTION
Fix --csv option doesn't escape newlines [https://github.com/sferik/t/issues/352](https://github.com/sferik/t/issues/352)

- Decode new line characters.
- Comma is already handled by adding quotes in CSV for description field.
- Add specs for `decode_full_text` method in `utils.rb`