### PR TITLE
Fix Markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If the output looks something like this, you're in good shape:
     ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
 
 If the output looks more like this, you need to [install Ruby][ruby]:
+
 [ruby]: https://www.ruby-lang.org/en/downloads/
 
     ruby: command not found
@@ -46,6 +47,7 @@ or for Red Hat-based distros like Fedora and CentOS, type:
 (if necessary, adapt for your package manager)
 
 **On Windows**, you can install Ruby with [RubyInstaller][].
+
 [rubyinstaller]: http://rubyinstaller.org/downloads/
 
 ## Installation


### PR DESCRIPTION
There needs to be a newline before the links when using the `[link text][link_tag]` format.

You can see the current broken version (with no newlines) rendered at [this permalink](https://github.com/sferik/t/blob/d030de01018efe2ec8d7bcb889788a3830779f8a/README.md#dependencies) of the current state of `master`.

You can see the rendered version with this fix [at this permalink](https://github.com/tjschuck/t/blob/f7adf87c663ea418a7cf55d63adc8b3d902480e6/README.md#dependencies).