### PR TITLE
Fix Rubocop (and therefore CI)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Lint/EndAlignment:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Metrics/BlockNesting:
   Max: 2
 
@@ -59,6 +63,9 @@ Style/EachWithObject:
   Enabled: false
 
 Style/Encoding:
+  Enabled: false
+
+Style/IndentHeredoc:
   Enabled: false
 
 Style/Lambda:

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,4 @@ Dir.glob('tasks/*.rake').each { |r| import r }
 
 task release: ['completion:zsh', 'completion:bash']
 task test: :spec
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]

--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'forwardable'
 require 'oauth'
 require 'thor'
@@ -30,7 +31,7 @@ module T
 
     check_unknown_options!
 
-    class_option 'color', aliases: '-C', type: :string, enum: %w(icon auto never), default: 'auto', desc: 'Control how color is used in output'
+    class_option 'color', aliases: '-C', type: :string, enum: %w[icon auto never], default: 'auto', desc: 'Control how color is used in output'
     class_option 'profile', aliases: '-P', type: :string, default: File.join(File.expand_path('~'), T::RCFile::FILE_NAME), desc: 'Path to RC file', banner: 'FILE'
 
     def initialize(*)
@@ -153,7 +154,7 @@ module T
         end
       end
     end
-    map %w(directmessages dms) => :direct_messages
+    map %w[directmessages dms] => :direct_messages
 
     desc 'direct_messages_sent', "Returns the #{DEFAULT_NUM_RESULTS} most recent Direct Messages you've sent."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -188,7 +189,7 @@ module T
         end
       end
     end
-    map %w(directmessagessent sent_messages sentmessages sms) => :direct_messages_sent
+    map %w[directmessagessent sent_messages sentmessages sms] => :direct_messages_sent
 
     desc 'dm USER MESSAGE', 'Sends that person a Direct Message.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
@@ -198,7 +199,7 @@ module T
       direct_message = client.create_direct_message(user, message)
       say "Direct Message sent from @#{@rcfile.active_profile[0]} to @#{direct_message.recipient.screen_name}."
     end
-    map %w(d m) => :dm
+    map %w[d m] => :dm
 
     desc 'does_contain [USER/]LIST USER', 'Find out whether a list contains a user.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
@@ -216,7 +217,7 @@ module T
         abort "No, #{list_name} does not contain @#{user}."
       end
     end
-    map %w(dc doescontain) => :does_contain
+    map %w[dc doescontain] => :does_contain
 
     desc 'does_follow USER [USER]', 'Find out whether one user follows another.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
@@ -244,7 +245,7 @@ module T
         abort "No, @#{user1} does not follow @#{user2}."
       end
     end
-    map %w(df doesfollow) => :does_follow
+    map %w[df doesfollow] => :does_follow
 
     desc 'favorite TWEET_ID [TWEET_ID...]', 'Marks Tweets as favorites.'
     def favorite(status_id, *status_ids)
@@ -259,7 +260,7 @@ module T
       say
       say "Run `#{File.basename($PROGRAM_NAME)} delete favorite #{status_ids.join(' ')}` to unfavorite."
     end
-    map %w(fave favourite) => :favorite
+    map %w[fave favourite] => :favorite
 
     desc 'favorites [USER]', "Returns the #{DEFAULT_NUM_RESULTS} most recent Tweets you favorited."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -288,7 +289,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(faves favourites) => :favorites
+    map %w[faves favourites] => :favorites
 
     desc 'follow USER [USER...]', 'Allows you to start following users.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify input as Twitter user IDs instead of screen names.'
@@ -307,7 +308,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def followings(user = nil)
       if user
@@ -328,7 +329,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def followings_following(user1, user2 = nil)
       require 't/core_ext/string'
@@ -347,7 +348,7 @@ module T
       end
       print_users(users)
     end
-    map %w(ff followingsfollowing) => :followings_following
+    map %w[ff followingsfollowing] => :followings_following
 
     desc 'followers [USER]', 'Returns a list of the people who follow you on Twitter.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -355,7 +356,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def followers(user = nil)
       if user
@@ -376,7 +377,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def friends(user = nil)
       user = if user
@@ -401,7 +402,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def groupies(user = nil)
       user = if user
@@ -419,7 +420,7 @@ module T
       end
       print_users(users)
     end
-    map %w(disciples) => :groupies
+    map %w[disciples] => :groupies
 
     desc 'intersection USER [USER...]', 'Displays the intersection of users followed by the specified users.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -427,8 +428,8 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
-    method_option 'type', aliases: '-t', type: :string, enum: %w(followers followings), default: 'followings', desc: 'Specify the type of intersection.'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'type', aliases: '-t', type: :string, enum: %w[followers followings], default: 'followings', desc: 'Specify the type of intersection.'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def intersection(first_user, *users)
       users.push(first_user)
@@ -451,7 +452,7 @@ module T
       end
       print_users(users)
     end
-    map %w(overlap) => :intersection
+    map %w[overlap] => :intersection
 
     desc 'leaders [USER]', "Returns the list of people who you follow but don't follow you back."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -459,7 +460,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def leaders(user = nil)
       user = if user
@@ -484,7 +485,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(members mode since slug subscribers), default: 'slug', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[members mode since slug subscribers], default: 'slug', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def lists(user = nil)
       lists = if user
@@ -502,7 +503,7 @@ module T
       opts = {count: MAX_SEARCH_RESULTS, include_entities: false}
       tweets = client.search('lang:ja', opts)
       tweets.each do |tweet|
-        say(tweet.text.gsub(/[^\u3000\u3040-\u309f]/, '').reverse, [:bold, :green, :on_black], false)
+        say(tweet.text.gsub(/[^\u3000\u3040-\u309f]/, '').reverse, %i[bold green on_black], false)
       end
     end
 
@@ -522,7 +523,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(replies) => :mentions
+    map %w[replies] => :mentions
 
     desc 'mute USER [USER...]', 'Mute users.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify input as Twitter user IDs instead of screen names.'
@@ -540,7 +541,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def muted
       muted_ids = client.muted_ids.to_a
@@ -550,7 +551,7 @@ module T
       end
       print_users(muted_users)
     end
-    map %w(mutes) => :muted
+    map %w[mutes] => :muted
 
     desc 'open USER', "Opens that user's profile in a web browser."
     method_option 'display-uri', aliases: '-d', type: :boolean, desc: 'Display the requested URL instead of attempting to open it.'
@@ -626,7 +627,7 @@ module T
       end
       say "@#{@rcfile.active_profile[0]} reported #{pluralize(number, 'user')}."
     end
-    map %w(report reportspam spam) => :report_spam
+    map %w[report reportspam spam] => :report_spam
 
     desc 'retweet TWEET_ID [TWEET_ID...]', 'Sends Tweets to your followers.'
     def retweet(status_id, *status_ids)
@@ -641,7 +642,7 @@ module T
       say
       say "Run `#{File.basename($PROGRAM_NAME)} delete status #{retweets.collect(&:id).join(' ')}` to undo."
     end
-    map %w(rt) => :retweet
+    map %w[rt] => :retweet
 
     desc 'retweets [USER]', "Returns the #{DEFAULT_NUM_RESULTS} most recent Retweets by a user."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -668,7 +669,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(rts) => :retweets
+    map %w[rts] => :retweets
 
     desc 'retweets_of_me', "Returns the #{DEFAULT_NUM_RESULTS} most recent Tweets of the authenticated user that have been retweeted by others."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -686,7 +687,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(retweetsofme) => :retweets_of_me
+    map %w[retweetsofme] => :retweets_of_me
 
     desc 'ruler', 'Prints a 140-character ruler'
     method_option 'indent', aliases: '-i', type: :numeric, default: 0, desc: 'The number of spaces to print before the ruler.'
@@ -747,7 +748,7 @@ module T
     desc 'timeline [USER]', "Returns the #{DEFAULT_NUM_RESULTS} most recent Tweets posted by a user."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
     method_option 'decode_uris', aliases: '-d', type: :boolean, desc: 'Decodes t.co URLs into their original form.'
-    method_option 'exclude', aliases: '-e', type: :string, enum: %w(replies retweets), desc: 'Exclude certain types of Tweets from the results.', banner: 'TYPE'
+    method_option 'exclude', aliases: '-e', type: :string, enum: %w[replies retweets], desc: 'Exclude certain types of Tweets from the results.', banner: 'TYPE'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'max_id', aliases: '-m', type: :numeric, desc: 'Returns only the results with an ID less than the specified ID.'
@@ -776,7 +777,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(tl) => :timeline
+    map %w[tl] => :timeline
 
     desc 'trends [WOEID]', 'Returns the top 50 trending topics.'
     method_option 'exclude-hashtags', aliases: '-x', type: :boolean, desc: 'Remove all hashtags from the trends list.'
@@ -792,7 +793,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(country name parent type woeid), default: 'name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[country name parent type woeid], default: 'name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def trend_locations
       places = client.trend_locations
@@ -827,7 +828,7 @@ module T
         print_attribute(places, :name)
       end
     end
-    map %w(locations trendlocations) => :trend_locations
+    map %w[locations trendlocations] => :trend_locations
 
     desc 'unfollow USER [USER...]', 'Allows you to stop following users.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify input as Twitter user IDs instead of screen names.'
@@ -856,7 +857,7 @@ module T
       say
       say "Run `#{File.basename($PROGRAM_NAME)} delete status #{status.id}` to delete."
     end
-    map %w(post tweet) => :update
+    map %w[post tweet] => :update
 
     desc 'users USER [USER...]', 'Returns a list of users you specify.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -864,7 +865,7 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def users(user, *users)
       users.unshift(user)
@@ -876,14 +877,14 @@ module T
       end
       print_users(users)
     end
-    map %w(stats) => :users
+    map %w[stats] => :users
 
     desc 'version', 'Show version.'
     def version
       require 't/version'
       say T::Version
     end
-    map %w(-v --version) => :version
+    map %w[-v --version] => :version
 
     desc 'whois USER', 'Retrieves profile information for the user.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -917,7 +918,7 @@ module T
         print_table(array)
       end
     end
-    map %w(user) => :whois
+    map %w[user] => :whois
 
     desc 'whoami', 'Retrieves profile information for the authenticated user.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'

--- a/lib/t/delete.rb
+++ b/lib/t/delete.rb
@@ -48,7 +48,7 @@ module T
         end
       end
     end
-    map %w(d m) => :dm
+    map %w[d m] => :dm
 
     desc 'favorite TWEET_ID [TWEET_ID...]', 'Delete favorites.'
     method_option 'force', aliases: '-f', type: :boolean
@@ -70,7 +70,7 @@ module T
         end
       end
     end
-    map %w(fave favourite) => :favorite
+    map %w[fave favourite] => :favorite
 
     desc 'list LIST', 'Delete a list.'
     method_option 'force', aliases: '-f', type: :boolean
@@ -129,6 +129,6 @@ module T
         end
       end
     end
-    map %w(post tweet update) => :status
+    map %w[post tweet update] => :status
   end
 end

--- a/lib/t/list.rb
+++ b/lib/t/list.rb
@@ -71,14 +71,14 @@ module T
         print_table(array)
       end
     end
-    map %w(details) => :information
+    map %w[details] => :information
 
     desc 'members [USER/]LIST', 'Returns the members of a Twitter list.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def members(user_list)
       owner, list_name = extract_owner(user_list, options)
@@ -120,6 +120,6 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(tl) => :timeline
+    map %w[tl] => :timeline
   end
 end

--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -121,7 +121,7 @@ module T
         print_identicon(from_user, message)
         say
       when 'auto'
-        say("   @#{from_user}", [:bold, :yellow])
+        say("   @#{from_user}", %i[bold yellow])
         print_wrapped(HTMLEntities.new.decode(message), indent: 3)
       else
         say("   @#{from_user}")
@@ -140,7 +140,7 @@ module T
       lines.unshift(set_color("  @#{from_user}", :bold, :yellow))
       lines.concat(Array.new([3 - lines.length, 0].max) { '' })
 
-      $stdout.puts lines.zip(icon.lines).map { |x, i| "  #{i || '      '}#{x}" }
+      $stdout.puts(lines.zip(icon.lines).map { |x, i| "  #{i || '      '}#{x}" })
     end
 
     def wrapped(message, options = {})

--- a/lib/t/search.rb
+++ b/lib/t/search.rb
@@ -85,7 +85,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(faves) => :favorites
+    map %w[faves] => :favorites
 
     desc 'list [USER/]LIST QUERY', 'Returns Tweets on a list that match the specified query.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -124,7 +124,7 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(replies) => :mentions
+    map %w[replies] => :mentions
 
     desc 'retweets [USER] QUERY', "Returns Tweets you've retweeted that match the specified query."
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
@@ -155,12 +155,12 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(rts) => :retweets
+    map %w[rts] => :retweets
 
     desc 'timeline [USER] QUERY', 'Returns Tweets in your timeline that match the specified query.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
     method_option 'decode_uris', aliases: '-d', type: :boolean, desc: 'Decodes t.co URLs into their original form.'
-    method_option 'exclude', aliases: '-e', type: :string, enum: %w(replies retweets), desc: 'Exclude certain types of Tweets from the results.', banner: 'TYPE'
+    method_option 'exclude', aliases: '-e', type: :string, enum: %w[replies retweets], desc: 'Exclude certain types of Tweets from the results.', banner: 'TYPE'
     method_option 'id', aliases: '-i', type: :boolean, desc: 'Specify user via ID instead of screen name.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'max_id', aliases: '-m', type: :numeric, desc: 'Returns only the results with an ID less than the specified ID.'
@@ -193,14 +193,14 @@ module T
       end
       print_tweets(tweets)
     end
-    map %w(tl) => :timeline
+    map %w[tl] => :timeline
 
     desc 'users QUERY', 'Returns users that match the specified query.'
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
-    method_option 'sort', aliases: '-s', type: :string, enum: %w(favorites followers friends listed screen_name since tweets tweeted), default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
+    method_option 'sort', aliases: '-s', type: :string, enum: %w[favorites followers friends listed screen_name since tweets tweeted], default: 'screen_name', desc: 'Specify the order of the results.', banner: 'ORDER'
     method_option 'unsorted', aliases: '-u', type: :boolean, desc: 'Output is not sorted.'
     def users(query)
       users = collect_with_page do |page|

--- a/lib/t/set.rb
+++ b/lib/t/set.rb
@@ -22,7 +22,7 @@ module T
       @rcfile.active_profile = {'username' => @rcfile[screen_name][consumer_key]['username'], 'consumer_key' => consumer_key}
       say "Active account has been updated to #{@rcfile.active_profile[0]}."
     end
-    map %w(account default) => :active
+    map %w[account default] => :active
 
     desc 'bio DESCRIPTION', 'Edits your Bio information on your Twitter profile.'
     def bio(description)
@@ -54,14 +54,14 @@ module T
       client.update_profile_background_image(File.new(File.expand_path(file)), tile: options['tile'], skip_status: true)
       say "@#{@rcfile.active_profile[0]}'s background image has been updated."
     end
-    map %w(background background_image) => :profile_background_image
+    map %w[background background_image] => :profile_background_image
 
     desc 'profile_image FILE', 'Sets the image on your Twitter profile.'
     def profile_image(file)
       client.update_profile_image(File.new(File.expand_path(file)))
       say "@#{@rcfile.active_profile[0]}'s image has been updated."
     end
-    map %w(avatar image) => :profile_image
+    map %w[avatar image] => :profile_image
 
     desc 'website URI', 'Sets the website field on your profile.'
     def website(uri)

--- a/lib/t/stream.rb
+++ b/lib/t/stream.rb
@@ -86,7 +86,7 @@ module T
         end
       end
     end
-    map %w(tl) => :timeline
+    map %w[tl] => :timeline
 
     desc 'matrix', 'Unfortunately, no one can be told what the Matrix is. You have to see it for yourself.'
     def matrix
@@ -97,7 +97,7 @@ module T
       end
       streaming_client.sample(language: 'ja') do |tweet|
         next unless tweet.is_a?(Twitter::Tweet)
-        say(tweet.text.gsub(/[^\u3000\u3040-\u309f]/, '').reverse, [:bold, :green, :on_black], false)
+        say(tweet.text.gsub(/[^\u3000\u3040-\u309f]/, '').reverse, %i[bold green on_black], false)
       end
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::CLI do

--- a/spec/delete_spec.rb
+++ b/spec/delete_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::Delete do

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::Editor do

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::List do
@@ -672,9 +673,9 @@ ID        Since         Last tweeted at  Tweets  Favorites  Listed  Following...
         allow($stdout).to receive(:"tty?").and_return(true)
         @list.timeline('presidents')
 
-        names = %w(mutgoff ironicsans pat_shaughnessy calebelston fivethirtyeight
+        names = %w[mutgoff ironicsans pat_shaughnessy calebelston fivethirtyeight
                    codeforamerica fbjork mbostock FakeDorsey al3x BarackObama
-                   JEG2 eveningedition dhh jasonfried sferik dwiskus)
+                   JEG2 eveningedition dhh jasonfried sferik dwiskus]
 
         icons = names.inject({}) { |acc, elem| acc.update(elem.to_sym => T::Identicon.for_user_name(elem)) }
 

--- a/spec/rcfile_spec.rb
+++ b/spec/rcfile_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::RCFile do
@@ -18,7 +19,7 @@ describe T::RCFile do
     it 'returns the profiles for a user' do
       rcfile = T::RCFile.instance
       rcfile.path = fixture_path + '/.trc'
-      expect(rcfile['testcli'].keys).to eq %w(abc123)
+      expect(rcfile['testcli'].keys).to eq %w[abc123]
     end
   end
 
@@ -35,7 +36,7 @@ describe T::RCFile do
           secret: 'jkl012',
         },
       }
-      expect(rcfile['testcli'].keys).to eq %w(abc123)
+      expect(rcfile['testcli'].keys).to eq %w[abc123]
     end
     it 'writes the data to a file' do
       rcfile = T::RCFile.instance
@@ -49,7 +50,7 @@ describe T::RCFile do
           secret: 'jkl012',
         },
       }
-      expect(rcfile['testcli'].keys).to eq %w(abc123)
+      expect(rcfile['testcli'].keys).to eq %w[abc123]
     end
     it 'is not be world writable' do
       rcfile = T::RCFile.instance
@@ -85,7 +86,7 @@ describe T::RCFile do
     it 'returns configuration' do
       rcfile = T::RCFile.instance
       rcfile.path = fixture_path + '/.trc'
-      expect(rcfile.configuration.keys).to eq %w(default_profile)
+      expect(rcfile.configuration.keys).to eq %w[default_profile]
     end
   end
 
@@ -109,7 +110,7 @@ describe T::RCFile do
     it 'returns default profile' do
       rcfile = T::RCFile.instance
       rcfile.path = fixture_path + '/.trc'
-      expect(rcfile.active_profile).to eq %w(testcli abc123)
+      expect(rcfile.active_profile).to eq %w[testcli abc123]
     end
   end
 
@@ -118,13 +119,13 @@ describe T::RCFile do
       rcfile = T::RCFile.instance
       rcfile.path = project_path + '/tmp/trc'
       rcfile.active_profile = {'username' => 'testcli', 'consumer_key' => 'abc123'}
-      expect(rcfile.active_profile).to eq %w(testcli abc123)
+      expect(rcfile.active_profile).to eq %w[testcli abc123]
     end
     it 'writes the data to a file' do
       rcfile = T::RCFile.instance
       rcfile.path = project_path + '/tmp/trc'
       rcfile.active_profile = {'username' => 'testcli', 'consumer_key' => 'abc123'}
-      expect(rcfile.active_profile).to eq %w(testcli abc123)
+      expect(rcfile.active_profile).to eq %w[testcli abc123]
     end
   end
 
@@ -185,7 +186,7 @@ describe T::RCFile do
       it 'loads default structure' do
         rcfile = T::RCFile.instance
         rcfile.path = File.expand_path('../fixtures/foo', __FILE__)
-        expect(rcfile.load_file.keys.sort).to eq %w(configuration profiles)
+        expect(rcfile.load_file.keys.sort).to eq %w[configuration profiles]
       end
     end
   end
@@ -213,7 +214,7 @@ describe T::RCFile do
     it 'returns profiles' do
       rcfile = T::RCFile.instance
       rcfile.path = fixture_path + '/.trc'
-      expect(rcfile.profiles.keys).to eq %w(testcli)
+      expect(rcfile.profiles.keys).to eq %w[testcli]
     end
   end
 end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::Search do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::Set do

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -157,7 +157,7 @@ describe T::Stream do
     end
     it 'prints the tweet' do
       expect(@stream).to receive(:print_message)
-      @stream.search(%w(twitter gem))
+      @stream.search(%w[twitter gem])
     end
     context '--csv' do
       before do
@@ -166,7 +166,7 @@ describe T::Stream do
       it 'outputs in CSV format' do
         allow(@streaming_client).to receive(:before_request)
         expect(@stream).to receive(:print_csv_tweet).with(any_args)
-        @stream.search(%w(twitter gem))
+        @stream.search(%w[twitter gem])
       end
     end
     context '--long' do
@@ -177,7 +177,7 @@ describe T::Stream do
         allow(@streaming_client).to receive(:before_request)
         allow(@streaming_client).to receive(:filter).with(track: 'twitter,gem').and_yield(@tweet)
         expect(@stream).to receive(:print_table).with(any_args)
-        @stream.search(%w(twitter gem))
+        @stream.search(%w[twitter gem])
       end
     end
     it 'performs a REST search when the stream initializes' do
@@ -190,7 +190,7 @@ describe T::Stream do
     it 'invokes Twitter::Streaming::Client#filter' do
       allow(@streaming_client).to receive(:filter)
       expect(@streaming_client).to receive(:filter).with(track: 'twitter,gem')
-      @stream.search(%w(twitter gem))
+      @stream.search(%w[twitter gem])
     end
   end
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'helper'
 
 describe T::Utils do

--- a/t.gemspec
+++ b/t.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 't/version'
@@ -16,11 +17,11 @@ Gem::Specification.new do |spec|
   spec.description = 'A command-line power tool for Twitter.'
   spec.email = 'sferik@gmail.com'
   spec.executables = Dir['bin/*'].map { |f| File.basename(f) }
-  spec.files = %w(CONTRIBUTING.md LICENSE.md README.md t.gemspec) + Dir['bin/*'] + Dir['lib/**/*.rb']
+  spec.files = %w[CONTRIBUTING.md LICENSE.md README.md t.gemspec] + Dir['bin/*'] + Dir['lib/**/*.rb']
   spec.homepage = 'http://sferik.github.com/t/'
-  spec.licenses = %w(MIT)
+  spec.licenses = %w[MIT]
   spec.name = 't'
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
   spec.required_ruby_version = '>= 2'
   spec.summary = 'CLI for Twitter'
   spec.version = T::Version

--- a/tasks/bash.rake
+++ b/tasks/bash.rake
@@ -103,7 +103,7 @@ module BashCompletion
     end
 
     def global_options
-      %w(-H --host -C --color -P --profile)
+      %w[-H --host -C --color -P --profile]
     end
 
     def global_options_args


### PR DESCRIPTION
Right now, CI is failing for all pull requests because of Rubocop failures.  This PR is three tiers of "fix" to that issue in three commits:

1. <s>d9b69c4 — Rubocop itself was failing to even run because of out-of-date parameter names.

    Before this change, you’d get the following error:

    ```
    $ rake rubocop
    Running RuboCop...
    Error: obsolete parameter IndentWhenRelativeTo (for Style/CaseIndentation) found in /Users/tjschuck/Code/t/.rubocop.yml
    `IndentWhenRelativeTo` has been renamed to `EnforcedStyle`
    obsolete parameter AlignWith (for Lint/EndAlignment) found in /Users/tjschuck/Code/t/.rubocop.yml
    `AlignWith` has been renamed to `EnforcedStyleAlignWith`
    RuboCop failed!
    ```

    </s> [_Rebased out because this was done on master in ee80a3cb24387ba5d30795cac90ce9bd385b84cb and 64fcb6abd7a6b21a598736bab2a70380f2c30a3c_]

2. 4bc49a7 — once Rubocop was fixed to run at all, it reported hundreds of offenses.  This commit fixes all the actual "violations" per the Rubocop YML via `rake rubocop:auto_correct`.

3. b9d6ad1 — Add two new Rubocop directives to account for defaults that shouldn't be considered issues in this codebase.

    1. Set `Metrics/BlockLength` as disabled for the `spec` directory.  Prior to this change, you get a bunch of failures like:

        ```
        spec/set_spec.rb:5:1: C: Block has too many lines. [138/25]
        describe T::Set do ...
        ^^^^^^^^^^^^^^^^^^
        ```

        But the blocklength validation doesn’t really make sense when assessing files written with the RSpec DSL, since when written properly, the specs are just very long blocks themselves.

    2. Disable `Style/IndentHeredoc`.  For Ruby 2.3+, the recommendation from Rubocop is just to use `<<~` or to use "some library (e.g. ActiveSupport's String#strip_heredoc)" for earlier versions of Ruby.

        However, the places that heredocs are being used are to test the output, and those are actually testing the spacing itself explicitly, so it doesn't make sense to squish the indentation out when it's present in this case anyway.
