### PR TITLE
Fix order dependent tests by resetting `host_os` after changing

### DIFF
--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -20,6 +20,11 @@ describe T::Editor do
     context 'no $VISUAL or $EDITOR set' do
       before do
         ENV['EDITOR'] = ENV['VISUAL'] = nil
+        @old_host_os = RbConfig::CONFIG['host_os']
+      end
+
+      after do
+        RbConfig::CONFIG['host_os'] = @old_host_os
       end
 
       context 'host_os is Mac OSX' do
@@ -79,6 +84,14 @@ describe T::Editor do
   end
 
   context 'when fetching system editor' do
+    before do
+      @old_host_os = RbConfig::CONFIG['host_os']
+    end
+
+    after do
+      RbConfig::CONFIG['host_os'] = @old_host_os
+    end
+
     context 'on a mac' do
       before do
         RbConfig::CONFIG['host_os'] = 'darwin12.2.0'


### PR DESCRIPTION
Can be red/greened with a seed of `34156`, and more minimally with:

    bundle exec rspec ./spec/editor_spec.rb ./spec/list_spec.rb --seed 34156

Particularly, the tests of color output in `list_spec.rb` fail when the OS is left as `mswin` in `editor_spec.rb`, since Thor does not display colored output on Windows (see [Thor's shell.rb#L14-L16](https://github.com/erikhuda/thor/blob/4b95e2e73408d2301a0c5513931f542c25e864b4/lib/thor/shell.rb#L14-L16)).

(CI is failing on this PR unrelated to this change, and would be fixed by https://github.com/sferik/t/pull/369.)