### PR TITLE
Adds --full-text option to direct-messages command. Fixes #371

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -124,6 +124,7 @@ module T
     method_option 'csv', aliases: '-c', type: :boolean, desc: 'Output in CSV format.'
     method_option 'decode_uris', aliases: '-d', type: :boolean, desc: 'Decodes t.co URLs into their original form.'
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
+    method_option 'full_text', aliases: '-f', type: :boolean, desc: 'Fetch full texts.'
     method_option 'number', aliases: '-n', type: :numeric, default: DEFAULT_NUM_RESULTS, desc: 'Limit the number of results.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     method_option 'reverse', aliases: '-r', type: :boolean, desc: 'Reverse the order of the sort.'
@@ -131,6 +132,7 @@ module T
       count = options['number'] || DEFAULT_NUM_RESULTS
       opts = {}
       opts[:include_entities] = !!options['decode_uris']
+      opts[:full_text] = true if options['full_text']
       direct_messages = collect_with_count(count) do |count_opts|
         client.direct_messages(count_opts.merge(opts))
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -209,6 +209,17 @@ ID,Posted at,Screen name,Text
         expect(a_get('/1.1/direct_messages.json').with(query: {count: '20', include_entities: 'true'})).to have_been_made
       end
     end
+    context '--full-text' do
+      before do
+        @cli.options = @cli.options.merge('full_text' => true)
+        stub_get('/1.1/direct_messages.json').with(query: {count: '20', include_entities: 'false', full_text: 'true'}).to_return(body: fixture('direct_messages.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/direct_messages.json').with(query: {count: '10', max_id: '1624782205', include_entities: 'false', full_text: 'true'}).to_return(body: fixture('empty_array.json'), headers: {content_type: 'application/json; charset=utf-8'})
+      end
+      it 'requests the correct resource' do
+        @cli.direct_messages
+        expect(a_get('/1.1/direct_messages.json').with(query: {count: '20', include_entities: 'false', full_text: 'true'})).to have_been_made
+      end
+    end
     context '--long' do
       before do
         @cli.options = @cli.options.merge('long' => true)


### PR DESCRIPTION
What title says. This option is supported directly by the twitter gem and API so it's a very small change.

```
    bundle exec bin/t help direct_messages
    Usage:
      t direct_messages

    Options:
      -c, [--csv], [--no-csv]                        # Output in CSV format.
      -d, [--decode-uris], [--no-decode-uris]        # Decodes t.co URLs into their original form.
      -l, [--long], [--no-long]                      # Output in long format.
=>    -f, [--full-text], [--no-full-text]            # Fetch full texts.                <=
      -n, [--number=N]                               # Limit the number of results.
                                                     # Default: 20
      -a, [--relative-dates], [--no-relative-dates]  # Show relative dates.
      -r, [--reverse], [--no-reverse]                # Reverse the order of the sort.
      -C, [--color=COLOR]                            # Control how color is used in output
                                                     # Default: auto
                                                     # Possible values: icon, auto, never
      -P, [--profile=FILE]                           # Path to RC file
                                                     # Default: /Users/sergio/.trc

    Returns the 20 most recent Direct Messages sent to you.
```

I guess it would make sense to make this the default when `--csv` is present too, but I didn't want to change the behaviour of an preexisting option unless mantainers suggest so (feel free to suggest this or any other change).

Thanks for the `t` tool, it's awesome!