### PR TITLE
cli: fix BASE_URL location

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -79,7 +79,7 @@ module T
       open_or_print('https://apps.twitter.com', dry_run: options['display-uri'])
       key = ask 'Enter your API key:'
       secret = ask 'Enter your API secret:'
-      consumer = OAuth::Consumer.new(key, secret, site: Twitter::REST::Client::BASE_URL)
+      consumer = OAuth::Consumer.new(key, secret, site: Twitter::REST::Request::BASE_URL)
       request_token = consumer.get_request_token
       uri = generate_authorize_uri(consumer, request_token)
       say
@@ -973,7 +973,7 @@ module T
         value =~ /"(.*?)"/
         "#{key}=#{CGI.escape(Regexp.last_match[1])}"
       end.join('&')
-      "#{Twitter::REST::Client::BASE_URL}#{request.path}?#{params}"
+      "#{Twitter::REST::Request::BASE_URL}#{request.path}?#{params}"
     end
 
     def pin_auth_parameters


### PR DESCRIPTION
It's been moved to `Request` from `Client`