### PR TITLE
Fix version dependencies and fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'simplecov', '>= 0.9'
   gem 'timecop'
   gem 'tins'
-  gem 'webmock', '>= 1.10.1'
+  gem 'webmock', '>= 3.1.0'
 end
 
 gemspec

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3898,7 +3898,7 @@ WOEID     Parent ID  Type       Name           Country
       it 'requests the correct resource' do
         @cli.update('Testing')
         expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')).to have_been_made
-        expect(a_post('/1.1/statuses/update_with_media.json')).to have_been_made
+        expect(a_post('/1.1/statuses/update.json')).to have_been_made
       end
       it 'has the correct output' do
         @cli.update('Testing')

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2550,7 +2550,7 @@ ID                   Posted at     Screen name       Text
     context 'with file' do
       before do
         @cli.options = @cli.options.merge('file' => fixture_path + '/long.png')
-        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')
+        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('media.json'), headers: {content_type: 'application/json; charset=utf-8'})
         stub_post('/1.1/statuses/update.json').to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
@@ -3892,7 +3892,7 @@ WOEID     Parent ID  Type       Name           Country
     context 'with file' do
       before do
         @cli.options = @cli.options.merge('file' => fixture_path + '/long.png')
-        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')
+        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('media.json'), headers: {content_type: 'application/json; charset=utf-8'})
         stub_post('/1.1/statuses/update.json').to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do

--- a/spec/fixtures/media.json
+++ b/spec/fixtures/media.json
@@ -1,0 +1,1 @@
+{"image":{"w":428,"h":428,"image_type":"image/png"},"media_id":470030289822314497,"media_id_string":"470030289822314497","size":68900}

--- a/t.gemspec
+++ b/t.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'oauth', '~> 0.5.1'
   spec.add_dependency 'retryable', '~> 2.0'
   spec.add_dependency 'thor', ['>= 0.19.1', '< 2']
-  spec.add_dependency 'twitter', '~> 6.0'
+  spec.add_dependency 'twitter', '~> 6.2'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.author = 'Erik Michaels-Ober'
   spec.description = 'A command-line power tool for Twitter.'


### PR DESCRIPTION
Tests (and the gem itself, actually) are currently broken on master.  This gets tests passing (and the gem working!), particularly by fixing the functionality via updating necessarily updated dependencies and tweaking some app code to match.

1. 00724a5 bumps the version dependency of the `twitter` gem. b40e208 (on master) changed the location of `BASE_URL` from `Twitter::REST::Client` to `Twitter::REST::Request`, but that change happened in version 6.2.0 of the twitter gem, so the dependency here needs to be bumped to match.

2. 56c2aa3 bumps the necessary version of `webmock`.  `twitter` had to be bumped to 6.2.0 per (1) above, but [6.2.0 of `twitter` has `http ~> 3.0` as a dependency](https://rubygems.org/gems/twitter/versions/6.2.0).  http 3.0.0 compatibility was [added to webmock 3.1.0](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#310), so this bumps the minimum version of webmock to match.

3. 98d505c updates a test to match the updated implementation in `twitter` 6.2.0.  As of sferik/twitter@e1e0095#diff-5ffd489b9cb331064f65077d37562b9c, the twitter gem no longer uses the deprecated `update_with_media` endpoint — it now calls `upload` followed by `update` with the previously uploaded media IDs.  This just makes the tests in `t` match.

4. 8d95467 fixes the `no implicit conversion of Symbol into Integer` error that's happening on master CI.  The `twitter` gem depends on the `media_id` key that’s returned as part of the `upload` request, so this just adds a fixture for the stubbed request that includes the expected key.

----

You might notice that **CI is still red on this branch**.  _However_ that's because of Rubocop, not tests.  If you look at CI, all the tests are now passing with these changes.

https://github.com/sferik/t/pull/369 will fix the _Rubocop_ issues, so that PR + this PR will should give green CI on master.