### PR TITLE
Update ruler length to 280 characters

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -688,10 +688,10 @@ module T
     end
     map %w(retweetsofme) => :retweets_of_me
 
-    desc 'ruler', 'Prints a 140-character ruler'
+    desc 'ruler', 'Prints a 280-character ruler'
     method_option 'indent', aliases: '-i', type: :numeric, default: 0, desc: 'The number of spaces to print before the ruler.'
     def ruler
-      markings = '----|'.chars.cycle.take(140).join
+      markings = '----|'.chars.cycle.take(280).join
       say "#{' ' * options['indent'].to_i}#{markings}"
     end
 


### PR DESCRIPTION
Per the recent Twitter update from 140-character to 280-character tweet lengths, a 140-character ruler is now obsolete. This supports the new 280-character max tweet length.