### PR TITLE
BUGFIX: twitter gem v6.2.0 introduces breaking changes

### DIFF
--- a/t.gemspec
+++ b/t.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'oauth', '~> 0.5.1'
   spec.add_dependency 'retryable', '~> 2.0'
   spec.add_dependency 'thor', ['>= 0.19.1', '< 2']
-  spec.add_dependency 'twitter', '~> 6.0'
+  spec.add_dependency 'twitter', '~> 6.1.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.author = 'Erik Michaels-Ober'
   spec.description = 'A command-line power tool for Twitter.'


### PR DESCRIPTION
Pinned the twitter dependency to v6.1.x.